### PR TITLE
fix duplicate sending of the initial query

### DIFF
--- a/client.go
+++ b/client.go
@@ -377,10 +377,6 @@ func (c *client) periodicQuery(ctx context.Context, params *lookupParams) error 
 	bo.Reset()
 
 	for {
-		// Do periodic query.
-		if err := c.query(params); err != nil {
-			return err
-		}
 		// Backoff and cancel logic.
 		wait := bo.NextBackOff()
 		if wait == backoff.Stop {
@@ -395,10 +391,12 @@ func (c *client) periodicQuery(ctx context.Context, params *lookupParams) error 
 			return nil
 		case <-ctx.Done():
 			return ctx.Err()
-
+		}
+		// Do periodic query.
+		if err := c.query(params); err != nil {
+			return err
 		}
 	}
-
 }
 
 // Performs the actual query by service name (browse) or service instance name (lookup),


### PR DESCRIPTION
This is a copy of grandcat#90.

In both Browse and Lookup, a query is send immediately. Therefore, we should first back off and then resend the query in periodicQuery().

@Stebalien, can you review this PR?