### PR TITLE
delete entries from the cache when the TTL expires

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See what needs to be done and submit a pull request :)
 * [x] Browse / Lookup / Register services
 * [x] Multiple IPv6 / IPv4 addresses support
 * [x] Send multiple probes (exp. back-off) if no service answers (*)
-* [ ] Timestamp entries for TTL checks
+* [x] Timestamp entries for TTL checks
 * [ ] Compare new multicasts with already received services
 
 _Notes:_

--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ This package requires **Go 1.7** (context in std lib) or later.
 ## Browse for services in your local network
 
 ```go
-// Discover all services on the network (e.g. _workstation._tcp)
-resolver, err := zeroconf.NewResolver(nil)
-if err != nil {
-    log.Fatalln("Failed to initialize resolver:", err.Error())
-}
-
 entries := make(chan *zeroconf.ServiceEntry)
 go func(results <-chan *zeroconf.ServiceEntry) {
     for entry := range results {
@@ -45,6 +39,7 @@ go func(results <-chan *zeroconf.ServiceEntry) {
 
 ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 defer cancel()
+// Discover all services on the network (e.g. _workstation._tcp)
 err = resolver.Browse(ctx, "_workstation._tcp", "local.", entries)
 if err != nil {
     log.Fatalln("Failed to browse:", err.Error())

--- a/client.go
+++ b/client.go
@@ -104,21 +104,12 @@ func applyOpts(options ...ClientOption) clientOpts {
 
 func (c *client) run(ctx context.Context, params *lookupParams) error {
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go c.mainloop(ctx, params)
 
-	if err := c.query(params); err != nil {
-		cancel()
-		return err
-	}
 	// If previous probe was ok, it should be fine now. In case of an error later on,
 	// the entries' queue is closed.
-	go func() {
-		if err := c.periodicQuery(ctx, params); err != nil {
-			cancel()
-		}
-	}()
-
-	return nil
+	return c.periodicQuery(ctx, params)
 }
 
 // defaultParams returns a default set of QueryParams.
@@ -362,6 +353,10 @@ func (c *client) periodicQuery(ctx context.Context, params *lookupParams) error 
 		}
 	}()
 	for {
+		// Do periodic query.
+		if err := c.query(params); err != nil {
+			return err
+		}
 		// Backoff and cancel logic.
 		wait := bo.NextBackOff()
 		if wait == backoff.Stop {
@@ -372,6 +367,7 @@ func (c *client) periodicQuery(ctx context.Context, params *lookupParams) error 
 		} else {
 			timer.Reset(wait)
 		}
+
 		select {
 		case <-timer.C:
 			// Wait for next iteration.
@@ -380,11 +376,10 @@ func (c *client) periodicQuery(ctx context.Context, params *lookupParams) error 
 			// Done here. Received a matching mDNS entry.
 			return nil
 		case <-ctx.Done():
+			if params.isBrowsing {
+				return nil
+			}
 			return ctx.Err()
-		}
-		// Do periodic query.
-		if err := c.query(params); err != nil {
-			return err
 		}
 	}
 }
@@ -409,11 +404,7 @@ func (c *client) query(params *lookupParams) error {
 		m.SetQuestion(serviceName, dns.TypePTR)
 	}
 	m.RecursionDesired = false
-	if err := c.sendQuery(m); err != nil {
-		return err
-	}
-
-	return nil
+	return c.sendQuery(m)
 }
 
 // Pack the dns.Msg and write to available connections (multicast)

--- a/client.go
+++ b/client.go
@@ -155,6 +155,8 @@ func newClient(opts clientOpts) (*client, error) {
 	}, nil
 }
 
+var cleanupFreq = 10 * time.Second
+
 // Start listeners and waits for the shutdown signal from exit channel
 func (c *client) mainloop(ctx context.Context, params *lookupParams) {
 	// start listening for responses
@@ -167,16 +169,28 @@ func (c *client) mainloop(ctx context.Context, params *lookupParams) {
 	}
 
 	// Iterate through channels from listeners goroutines
-	var entries, sentEntries map[string]*ServiceEntry
-	sentEntries = make(map[string]*ServiceEntry)
+	var entries map[string]*ServiceEntry
+	sentEntries := make(map[string]*ServiceEntry)
+
+	ticker := time.NewTicker(cleanupFreq)
+	defer ticker.Stop()
 	for {
+		var now time.Time
 		select {
 		case <-ctx.Done():
 			// Context expired. Notify subscriber that we are done here.
 			params.done()
 			c.shutdown()
 			return
+		case t := <-ticker.C:
+			for k, e := range sentEntries {
+				if t.After(e.Expiry) {
+					delete(sentEntries, k)
+				}
+			}
+			continue
 		case msg := <-msgCh:
+			now = time.Now()
 			entries = make(map[string]*ServiceEntry)
 			sections := append(msg.Answer, msg.Ns...)
 			sections = append(sections, msg.Extra...)
@@ -196,7 +210,7 @@ func (c *client) mainloop(ctx context.Context, params *lookupParams) {
 							params.Service,
 							params.Domain)
 					}
-					entries[rr.Ptr].TTL = rr.Hdr.Ttl
+					entries[rr.Ptr].Expiry = now.Add(time.Duration(rr.Hdr.Ttl) * time.Second)
 				case *dns.SRV:
 					if params.ServiceInstanceName() != "" && params.ServiceInstanceName() != rr.Hdr.Name {
 						continue
@@ -211,7 +225,7 @@ func (c *client) mainloop(ctx context.Context, params *lookupParams) {
 					}
 					entries[rr.Hdr.Name].HostName = rr.Target
 					entries[rr.Hdr.Name].Port = int(rr.Port)
-					entries[rr.Hdr.Name].TTL = rr.Hdr.Ttl
+					entries[rr.Hdr.Name].Expiry = now.Add(time.Duration(rr.Hdr.Ttl) * time.Second)
 				case *dns.TXT:
 					if params.ServiceInstanceName() != "" && params.ServiceInstanceName() != rr.Hdr.Name {
 						continue
@@ -225,7 +239,7 @@ func (c *client) mainloop(ctx context.Context, params *lookupParams) {
 							params.Domain)
 					}
 					entries[rr.Hdr.Name].Text = rr.Txt
-					entries[rr.Hdr.Name].TTL = rr.Hdr.Ttl
+					entries[rr.Hdr.Name].Expiry = now.Add(time.Duration(rr.Hdr.Ttl) * time.Second)
 				}
 			}
 			// Associate IPs in a second round as other fields should be filled by now.
@@ -249,7 +263,7 @@ func (c *client) mainloop(ctx context.Context, params *lookupParams) {
 
 		if len(entries) > 0 {
 			for k, e := range entries {
-				if e.TTL == 0 {
+				if !e.Expiry.After(now) {
 					delete(entries, k)
 					delete(sentEntries, k)
 					continue

--- a/examples/resolv/client.go
+++ b/examples/resolv/client.go
@@ -18,12 +18,6 @@ var (
 func main() {
 	flag.Parse()
 
-	// Discover all services on the network (e.g. _workstation._tcp)
-	resolver, err := zeroconf.NewResolver(nil)
-	if err != nil {
-		log.Fatalln("Failed to initialize resolver:", err.Error())
-	}
-
 	entries := make(chan *zeroconf.ServiceEntry)
 	go func(results <-chan *zeroconf.ServiceEntry) {
 		for entry := range results {
@@ -34,7 +28,8 @@ func main() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(*waitTime))
 	defer cancel()
-	err = resolver.Browse(ctx, *service, *domain, entries)
+	// Discover all services on the network (e.g. _workstation._tcp)
+	err := zeroconf.Browse(ctx, *service, *domain, entries)
 	if err != nil {
 		log.Fatalln("Failed to browse:", err.Error())
 	}

--- a/server.go
+++ b/server.go
@@ -21,6 +21,8 @@ const (
 	multicastRepetitions = 2
 )
 
+var defaultTTL uint32 = 3200
+
 // Register a service by given arguments. This call will take the system's hostname
 // and lookup IP by that hostname.
 func Register(instance, service, domain string, port int, text []string, ifaces []net.Interface) (*Server, error) {
@@ -173,7 +175,7 @@ func newServer(ifaces []net.Interface) (*Server, error) {
 		ipv4conn:       ipv4conn,
 		ipv6conn:       ipv6conn,
 		ifaces:         ifaces,
-		ttl:            3200,
+		ttl:            defaultTTL,
 		shouldShutdown: make(chan struct{}),
 	}
 

--- a/service.go
+++ b/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 )
 
 // ServiceRecord contains the basic description of a service, which contains instance name, service type & domain
@@ -103,12 +104,12 @@ func (l *lookupParams) disableProbing() {
 // used to answer multicast queries.
 type ServiceEntry struct {
 	ServiceRecord
-	HostName string   `json:"hostname"` // Host machine DNS name
-	Port     int      `json:"port"`     // Service Port
-	Text     []string `json:"text"`     // Service info served as a TXT record
-	TTL      uint32   `json:"ttl"`      // TTL of the service record
-	AddrIPv4 []net.IP `json:"-"`        // Host machine IPv4 address
-	AddrIPv6 []net.IP `json:"-"`        // Host machine IPv6 address
+	HostName string    `json:"hostname"` // Host machine DNS name
+	Port     int       `json:"port"`     // Service Port
+	Text     []string  `json:"text"`     // Service info served as a TXT record
+	Expiry   time.Time `json:"expiry"`   // Expiry of the service entry, will be converted to a TTL value
+	AddrIPv4 []net.IP  `json:"-"`        // Host machine IPv4 address
+	AddrIPv6 []net.IP  `json:"-"`        // Host machine IPv6 address
 }
 
 // NewServiceEntry constructs a ServiceEntry.

--- a/service_test.go
+++ b/service_test.go
@@ -146,4 +146,34 @@ func TestSubtype(t *testing.T) {
 			t.Fatalf("Expected port is %d, but got %d", mdnsPort, result.Port)
 		}
 	})
+
+	t.Run("ttl", func(t *testing.T) {
+		origTTL := defaultTTL
+		origCleanupFreq := cleanupFreq
+		defer func() {
+			defaultTTL = origTTL
+			cleanupFreq = origCleanupFreq
+		}()
+		defaultTTL = 2 // 2 seconds
+		cleanupFreq = 100 * time.Millisecond
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		go startMDNS(ctx, mdnsPort, mdnsName, mdnsSubtype, mdnsDomain)
+
+		entries := make(chan *ServiceEntry, 100)
+		if err := Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
+			t.Fatalf("Expected browse success, but got %v", err)
+		}
+
+		<-ctx.Done()
+		if len(entries) != 2 {
+			t.Fatalf("Expected to have received 2 entries, but got %d", len(entries))
+		}
+		res1 := <-entries
+		res2 := <-entries
+		if res1.ServiceInstanceName() != res2.ServiceInstanceName() {
+			t.Fatalf("expected the two entries to be identical")
+		}
+	})
 }

--- a/service_test.go
+++ b/service_test.go
@@ -40,12 +40,8 @@ func TestBasic(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	resolver, err := NewResolver(nil)
-	if err != nil {
-		t.Fatalf("Expected create resolver success, but got %v", err)
-	}
 	entries := make(chan *ServiceEntry, 100)
-	if err := resolver.Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
+	if err := Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
 		t.Fatalf("Expected browse success, but got %v", err)
 	}
 	<-ctx.Done()
@@ -69,11 +65,6 @@ func TestBasic(t *testing.T) {
 }
 
 func TestNoRegister(t *testing.T) {
-	resolver, err := NewResolver(nil)
-	if err != nil {
-		t.Fatalf("Expected create resolver success, but got %v", err)
-	}
-
 	// before register, mdns resolve shuold not have any entry
 	entries := make(chan *ServiceEntry)
 	go func(results <-chan *ServiceEntry) {
@@ -84,7 +75,7 @@ func TestNoRegister(t *testing.T) {
 	}(entries)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	if err := resolver.Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
+	if err := Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
 		t.Fatalf("Expected browse success, but got %v", err)
 	}
 	<-ctx.Done()
@@ -100,12 +91,8 @@ func TestSubtype(t *testing.T) {
 
 		time.Sleep(time.Second)
 
-		resolver, err := NewResolver(nil)
-		if err != nil {
-			t.Fatalf("Expected create resolver success, but got %v", err)
-		}
 		entries := make(chan *ServiceEntry, 100)
-		if err := resolver.Browse(ctx, mdnsSubtype, mdnsDomain, entries); err != nil {
+		if err := Browse(ctx, mdnsSubtype, mdnsDomain, entries); err != nil {
 			t.Fatalf("Expected browse success, but got %v", err)
 		}
 		<-ctx.Done()
@@ -136,12 +123,8 @@ func TestSubtype(t *testing.T) {
 
 		time.Sleep(time.Second)
 
-		resolver, err := NewResolver(nil)
-		if err != nil {
-			t.Fatalf("Expected create resolver success, but got %v", err)
-		}
 		entries := make(chan *ServiceEntry, 100)
-		if err := resolver.Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
+		if err := Browse(ctx, mdnsService, mdnsDomain, entries); err != nil {
 			t.Fatalf("Expected browse success, but got %v", err)
 		}
 		<-ctx.Done()


### PR DESCRIPTION
This is a copy of https://github.com/grandcat/zeroconf/pull/93.

Instead of saving the TTL value (an integer, measuring the time in seconds), we now save the expiry timestamp for every response we receive. A "cleanup" go routine then goes through our cache every 10s and removes entries that have expired.

@stebalien, could you review this PR?